### PR TITLE
Use a conlang generator to replace fake word

### DIFF
--- a/powercable/src/lib.rs
+++ b/powercable/src/lib.rs
@@ -78,9 +78,9 @@ pub fn generate_unique_name() -> String {
         });
     }
 
-    let mut c = word.chars();
-    match c.next() {
+    let mut char = word.chars();
+    match char.next() {
         None => String::new(),
-        Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
+        Some(first_char) => first_char.to_uppercase().collect::<String>() + char.as_str(),
     }
 }

--- a/powercable/src/lib.rs
+++ b/powercable/src/lib.rs
@@ -78,9 +78,9 @@ pub fn generate_unique_name() -> String {
         });
     }
 
-    let mut char = word.chars();
-    match char.next() {
+    let mut chars = word.chars();
+    match chars.next() {
         None => String::new(),
-        Some(first_char) => first_char.to_uppercase().collect::<String>() + char.as_str(),
+        Some(first_char) => first_char.to_uppercase().collect::<String>() + chars.as_str(),
     }
 }

--- a/powercable/src/lib.rs
+++ b/powercable/src/lib.rs
@@ -1,6 +1,4 @@
-use fake::faker::lorem::de_de::Word;
-use fake::Fake;
-use rand::Rng;
+use rand::{seq::IteratorRandom, Rng};
 
 pub mod charger;
 pub mod chart_entry;
@@ -63,5 +61,26 @@ pub fn get_id_from_topic(topic: &str) -> String {
 }
 
 pub fn generate_unique_name() -> String {
-    Word().fake()
+    let mut rng = rand::rng();
+    let vowels = "aeiou";
+    let consonants = "bcdfghjklmnpqrstvwxyz";
+    let rand_vowel = |rng: &mut rand::rngs::ThreadRng| vowels.chars().choose(rng).unwrap();
+    let rand_consonant = |rng: &mut rand::rngs::ThreadRng| consonants.chars().choose(rng).unwrap();
+
+    let mut word: String = "".to_owned();
+    for _ in 2..5 {
+        word.push_str(&match rng.random_range(0..=3) {
+            0 => format!("{}", rand_vowel(&mut rng)),
+            1 => format!("{}{}", rand_vowel(&mut rng), rand_consonant(&mut rng)), 
+            2 => format!("{}{}", rand_consonant(&mut rng), rand_vowel(&mut rng)),
+            3 => format!("{}{}{}", rand_consonant(&mut rng), rand_vowel(&mut rng), rand_consonant(&mut rng)),
+            _ => String::new(),
+        });
+    }
+
+    let mut c = word.chars();
+    match c.next() {
+        None => String::new(),
+        Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
+    }
 }


### PR DESCRIPTION
The issue with `Word().fake()` was that the names it generated had a very high rate of repetition. This caused MQTT to close old connections when a new client with an already known name showed up.
```
mosquitto_broker    | 1749127932: Client quis already connected, closing old connection.
```
Once the connection is lost the old client terminates, removing it from the simulation.