### PR TITLE
Vehicle: Fix random issue

### DIFF
--- a/power_grid_factory/src/main.rs
+++ b/power_grid_factory/src/main.rs
@@ -39,7 +39,7 @@ async fn main() {
 
     tracing::debug!("PowerGrid starting up...");
   
-    let mut power_grid = PowerGrid::spawn_new(10, 5, 15).await;
+    let power_grid = PowerGrid::spawn_new(10, 5, 15).await;
 
     tracing::debug!("PowerGrid spawned with {} turbines, {} chargers, and {} consumers.", 
         power_grid.turbine.len(), 

--- a/power_grid_factory/src/main.rs
+++ b/power_grid_factory/src/main.rs
@@ -39,7 +39,7 @@ async fn main() {
 
     tracing::debug!("PowerGrid starting up...");
   
-    let mut power_grid = PowerGrid::spawn_new(5, 5, 10).await;
+    let mut power_grid = PowerGrid::spawn_new(10, 5, 15).await;
 
     tracing::debug!("PowerGrid spawned with {} turbines, {} chargers, and {} consumers.", 
         power_grid.turbine.len(), 

--- a/powercable/src/lib.rs
+++ b/powercable/src/lib.rs
@@ -43,7 +43,7 @@ pub const VEHICLE_TOPIC: &str = "vehicle";
 pub const MQTT_BROKER: &str = "mosquitto_broker";
 pub const MQTT_BROKER_PORT: u16 = 1883;
 pub const MAP_UPDATE_SPEED_IN_SECS: u64 = 1;
-pub const RANDOM_SEED: u64 = 29_06_25; // Seed for random number generation
+pub const RANDOM_SEED: u64 = 30_06_25; // Seed for random number generation
 
 /// We use prime numbers to represent different types of entities in the system.
 /// This helps to ensure that the generated IDs are unique and can be easily distinguished.

--- a/vehicle/src/topic_handler.rs
+++ b/vehicle/src/topic_handler.rs
@@ -1,5 +1,5 @@
 use bytes::Bytes;
-use rand::Rng;
+use rand::{rngs::StdRng, Rng, SeedableRng};
 use tracing::{debug, info, trace, warn};
 use powercable::{generate_rnd_pos, tickgen::{Phase, TickPayload}, POWER_LOCATION_TOPIC, VEHICLE_TOPIC};
 use rumqttc::QoS;
@@ -66,7 +66,7 @@ pub async fn tick_handler(handler: SharedVehicle, payload: Bytes) {
 /// - `handler`: A shared reference to the vehicle handler, which contains the vehicle instance and the MQTT client.
 pub async fn process_tick(handler: SharedVehicle) { // TODO: rework this function cause its chaos
     let mut locked_handler = handler.lock().await;
-    let seed = locked_handler.seed.clone();
+    //let seed = locked_handler.seed.clone();
 
     if locked_handler.target_charger.is_none() {
         if locked_handler.vehicle.battery().get_soc() <= FIND_CHARGER_AT_LEAST { // If the vehicle low on battery, search for a charger
@@ -90,7 +90,8 @@ pub async fn process_tick(handler: SharedVehicle) { // TODO: rework this functio
             }
         } else {
             if locked_handler.vehicle.get_location() == locked_handler.vehicle.get_destination() {
-                let mut rng = rand::rng();
+                let seed = locked_handler.vehicle.get_seed();
+                let mut rng = StdRng::seed_from_u64(seed);
                 match rng.random_range(0..11) { // Average parking time is 3 hours (made up)
                     0 => {
                         locked_handler.vehicle.set_status(VehicleStatus::Random); // Generate new destination

--- a/vehicle/src/vehicle.rs
+++ b/vehicle/src/vehicle.rs
@@ -1,5 +1,5 @@
 use tracing::debug;
-use powercable::{tickgen::PHASE_AS_HOUR, Position, RANDOM_SEED};
+use powercable::{tickgen::PHASE_AS_HOUR, Position};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use serde::{Serialize, Deserialize};
 
@@ -86,6 +86,7 @@ pub struct Vehicle {
     battery: Battery,
     algorithm: VehicleAlgorithm,
     deadline: VehicleDeadline,
+    seed: u64,
 }
 
 impl Vehicle {
@@ -118,7 +119,8 @@ impl Vehicle {
             speed: 0,
             battery,
             algorithm: VehicleAlgorithm::Best,
-            deadline: VehicleDeadline { ticks_remaining: 12 * 24, target_soc: 0.8 }
+            deadline: VehicleDeadline { ticks_remaining: 12 * 24, target_soc: 0.8 },
+            seed: seed,
         }
     }
 
@@ -273,6 +275,14 @@ impl Vehicle {
     /// The deadline to which a the battery must be charged.
     pub fn get_deadline(&self) -> VehicleDeadline {
         self.deadline
+    }
+
+    /// # Returns
+    /// Current seed for deterministic randomness.
+    pub fn get_seed(&mut self) -> u64 {
+        let mut rng = StdRng::seed_from_u64(self.seed);
+        self.seed = rng.random();
+        self.seed
     }
 
     /// # Description

--- a/vehicle/src/vehicle.rs
+++ b/vehicle/src/vehicle.rs
@@ -72,6 +72,7 @@ pub struct VehicleDeadline {
 /// - `speed`: The speed of the vehicle in km/h.
 /// - `battery`: The battery of the vehicle, which contains information about its capacity, current charge level, and maximum charge rate.
 /// - `algorithm`: The algorithm used by the vehicle to determine its behavior when searching for a charger.
+/// - `seed`: To be used for randomness by this vehicle for deterministic but unique outcome.
 #[derive(Clone, Debug, Serialize)]
 pub struct Vehicle {
     name: String,
@@ -278,7 +279,7 @@ impl Vehicle {
     }
 
     /// # Returns
-    /// Current seed for deterministic randomness.
+    /// Current seed for deterministic randomness. Updates automatically.
     pub fn get_seed(&mut self) -> u64 {
         let mut rng = StdRng::seed_from_u64(self.seed);
         self.seed = rng.random();


### PR DESCRIPTION
After switching to a deterministic random generator all cars had the same seed, causing them to behave exactly the same (timing and destination). This fixes it by adding seed as a field in `Vehicle` and update it every time its getter is called.